### PR TITLE
StreamSaver.js を File System Access API で置き換え

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ tsconfig.json
 - Biome で静的解析・フォーマット
 - tsconfig.json はエディタの型チェック用に維持
 - runtime 依存パッケージなし
-- CDN 経由で動的読み込み: Vue.js 3.2, Bootstrap 5.0, StreamSaver.js 2.0, web-streams-polyfill
+- CDN 経由で動的読み込み: Bootstrap 5.3
+- ZIP 書き込みは File System Access API による自前実装 (Chrome/Edge のみ対応)
 
 ## アーキテクチャ
 
@@ -40,8 +41,8 @@ tsconfig.json
 3. **DownloadHelper** — 最上位クラス。UI 生成、ZIP ダウンロード、HTML 生成を統合
 
 主な機能:
-- ZIP ダウンロード（StreamSaver.js 経由）
-- Vue.js ベースのタグフィルタリング UI
+- ZIP ダウンロード（File System Access API + 自前 ZipWriter）
+- Bootstrap ベースのタグフィルタリング UI
 - リトライ機能付き fetch（レート制限対策）
 - ファイル名の Windows 互換エンコーディング（全角記号への置換）
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 ダウンローダーで使うパッケージ
 
+## 対応ブラウザ
+
+Chrome / Edge (File System Access API を使用)
+
 ## 使い方
 
 ```bash
-# yarn add git+https://github.com/ValerianDillon/download-helper.git#release/3.1.5
-npm install --save git+https://github.com/ValerianDillon/download-helper.git#release/3.1.5
+npm install --save github:ValerianDillon/download-helper#v3.5.0
 ```

--- a/download-helper.js
+++ b/download-helper.js
@@ -310,6 +310,103 @@ export class FileObject {
     return candidate.name === this.fileObj.name && candidate.url === this.fileObj.url;
   }
 }
+export const crc32Table = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0;i < 256; i++) {
+    let c = i;
+    for (let j = 0;j < 8; j++) {
+      c = c & 1 ? 3988292384 ^ c >>> 1 : c >>> 1;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+export function crc32(data) {
+  let crc = 4294967295;
+  for (let i = 0;i < data.length; i++) {
+    crc = crc32Table[(crc ^ data[i]) & 255] ^ crc >>> 8;
+  }
+  return (crc ^ 4294967295) >>> 0;
+}
+async function toUint8Array(parts) {
+  const blob = new Blob(parts);
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+export class ZipWriter {
+  writable;
+  offset = 0;
+  entries = [];
+  encoder = new TextEncoder;
+  constructor(writable) {
+    this.writable = writable;
+  }
+  async addFile(name, data) {
+    const nameBytes = this.encoder.encode(name);
+    const fileCrc = crc32(data);
+    const localHeaderOffset = this.offset;
+    const header = new ArrayBuffer(30);
+    const view = new DataView(header);
+    view.setUint32(0, 67324752, true);
+    view.setUint16(4, 20, true);
+    view.setUint16(6, 2048, true);
+    view.setUint16(8, 0, true);
+    view.setUint16(10, 0, true);
+    view.setUint16(12, 0, true);
+    view.setUint32(14, fileCrc, true);
+    view.setUint32(18, data.length, true);
+    view.setUint32(22, data.length, true);
+    view.setUint16(26, nameBytes.length, true);
+    view.setUint16(28, 0, true);
+    await this.write(new Uint8Array(header));
+    await this.write(nameBytes);
+    await this.write(data);
+    this.entries.push({ name: nameBytes, crc: fileCrc, size: data.length, offset: localHeaderOffset });
+  }
+  async close() {
+    const cdOffset = this.offset;
+    for (const entry of this.entries) {
+      const cdHeader = new ArrayBuffer(46);
+      const view = new DataView(cdHeader);
+      view.setUint32(0, 33639248, true);
+      view.setUint16(4, 20, true);
+      view.setUint16(6, 20, true);
+      view.setUint16(8, 2048, true);
+      view.setUint16(10, 0, true);
+      view.setUint16(12, 0, true);
+      view.setUint16(14, 0, true);
+      view.setUint32(16, entry.crc, true);
+      view.setUint32(20, entry.size, true);
+      view.setUint32(24, entry.size, true);
+      view.setUint16(28, entry.name.length, true);
+      view.setUint16(30, 0, true);
+      view.setUint16(32, 0, true);
+      view.setUint16(34, 0, true);
+      view.setUint16(36, 0, true);
+      view.setUint32(38, 0, true);
+      view.setUint32(42, entry.offset, true);
+      await this.write(new Uint8Array(cdHeader));
+      await this.write(entry.name);
+    }
+    const cdSize = this.offset - cdOffset;
+    const eocd = new ArrayBuffer(22);
+    const eocdView = new DataView(eocd);
+    eocdView.setUint32(0, 101010256, true);
+    eocdView.setUint16(4, 0, true);
+    eocdView.setUint16(6, 0, true);
+    eocdView.setUint16(8, this.entries.length, true);
+    eocdView.setUint16(10, this.entries.length, true);
+    eocdView.setUint32(12, cdSize, true);
+    eocdView.setUint32(16, cdOffset, true);
+    eocdView.setUint16(20, 0, true);
+    await this.write(new Uint8Array(eocd));
+    await this.writable.close();
+  }
+  async write(data) {
+    await this.writable.write(data);
+    this.offset += data.length;
+  }
+}
 
 export class DownloadHelper {
   utils;
@@ -323,18 +420,6 @@ export class DownloadHelper {
   bootJS = {
     src: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js",
     integrity: "sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
-  };
-  polyfillJS = {
-    src: "https://cdn.jsdelivr.net/npm/web-streams-polyfill@2.0.2/dist/ponyfill.min.js",
-    integrity: "sha384-ba6djMbY2Z/yqvSzlHRsh7WWPHEwE+TD2KdIhrpLv4q7+7izPZSlnWJe/t++aQOE"
-  };
-  streamSaverJS = {
-    src: "https://cdn.jsdelivr.net/npm/streamsaver@2.0.6/StreamSaver.js",
-    integrity: "sha384-Nqw6SzqA0IaGGLP/g9Y5h/bB8wBGXJ83TDjPs5OgxjX9mYZa5+oUc2Gym4xwZSSa"
-  };
-  zipStreamJS = {
-    src: "https://cdn.jsdelivr.net/npm/streamsaver@2.0.6/examples/zip-stream.js",
-    integrity: "sha384-g9gkHBj/J34a/2KwwHmm6VymJgH8EivePV3Nhl9rGu/eKHhK0OthrHe5S7fW88Pn"
   };
   async createDownloadUI(title) {
     document.head.innerHTML = "";
@@ -447,73 +532,58 @@ export class DownloadHelper {
   async downloadZip(downloadObj, progress, log, remainTime) {
     if (!this.isDownloadJsonObj(downloadObj))
       throw new Error("ダウンロード対象オブジェクトの型が不正");
-    const ui = this;
     const utils = this.utils;
-    await utils.embedScript(this.polyfillJS.src, this.polyfillJS.integrity);
-    await utils.embedScript(this.streamSaverJS.src, this.streamSaverJS.integrity);
-    await utils.embedScript(this.zipStreamJS.src, this.zipStreamJS.integrity);
     const encodedId = utils.encodeFileName(downloadObj.id);
-    const fileStream = streamSaver.createWriteStream(`${encodedId}.zip`);
-    const readableZipStream = new createWriter({
-      async pull(ctrl) {
-        const startTime = Math.floor(Date.now() / 1000);
-        let count = 0;
-        let failedCount = 0;
-        const enqueue = (fileBits, path) => ctrl.enqueue(new File(fileBits, `${encodedId}/${path}`));
-        log(`@${downloadObj.id} 投稿:${downloadObj.postCount} ファイル:${downloadObj.fileCount}`);
-        enqueue([ui.createRootHtmlFromPosts(downloadObj)], "index.html");
-        let postCount = 0;
-        for (const post of downloadObj.posts) {
-          log(`${post.originalName} (${++postCount}/${downloadObj.postCount})`);
-          const informationFile = utils.createInformationFile(post.informationText);
-          enqueue(informationFile.content, `${post.encodedName}/${utils.encodeFileName(informationFile.name)}`);
-          enqueue([ui.createHtmlFromBody(post.originalName, post.htmlText)], `${post.encodedName}/index.html`);
-          if (post.cover) {
-            log(`download ${post.cover.name}`);
-            const blob = await utils.fetchWithLimit(post.cover, 1);
-            if (blob) {
-              enqueue([blob], `${post.encodedName}/${post.cover.name}`);
-            }
-          }
-          let fileCount = 0;
-          for (const file of post.files) {
-            log(`download ${file.encodedName} (${++fileCount}/${post.files.length})`);
-            const blob = await utils.fetchWithLimit({ url: file.url, name: file.encodedName }, 1);
-            if (blob) {
-              enqueue([blob], `${post.encodedName}/${file.encodedName}`);
-            } else {
-              failedCount++;
-              console.error(`${file.encodedName}(${file.url})のダウンロードに失敗、読み飛ばすよ`);
-              log(`${file.encodedName}のダウンロードに失敗`);
-            }
-            count++;
-            setTimeout(() => {
-              if (count <= 0)
-                return;
-              const remain = Math.floor(Math.abs(Math.floor(Date.now() / 1000) - startTime) * (downloadObj.fileCount - count) / count);
-              const h = remain / (60 * 60) | 0;
-              const m = Math.ceil((remain - 60 * 60 * h) / 60);
-              remainTime(`${h}:${("00" + m).slice(-2)}`);
-              progress(count * 100 / downloadObj.fileCount | 0);
-            }, 0);
-            await utils.sleep(100);
-          }
+    const handle = await showSaveFilePicker({ suggestedName: `${encodedId}.zip` });
+    const writable = await handle.createWritable();
+    const zip = new ZipWriter(writable);
+    const enqueue = async (fileBits, path) => {
+      await zip.addFile(`${encodedId}/${path}`, await toUint8Array(fileBits));
+    };
+    const startTime = Math.floor(Date.now() / 1000);
+    let count = 0;
+    let failedCount = 0;
+    log(`@${downloadObj.id} 投稿:${downloadObj.postCount} ファイル:${downloadObj.fileCount}`);
+    await enqueue([this.createRootHtmlFromPosts(downloadObj)], "index.html");
+    let postCount = 0;
+    for (const post of downloadObj.posts) {
+      log(`${post.originalName} (${++postCount}/${downloadObj.postCount})`);
+      const informationFile = utils.createInformationFile(post.informationText);
+      await enqueue(informationFile.content, `${post.encodedName}/${utils.encodeFileName(informationFile.name)}`);
+      await enqueue([this.createHtmlFromBody(post.originalName, post.htmlText)], `${post.encodedName}/index.html`);
+      if (post.cover) {
+        log(`download ${post.cover.name}`);
+        const blob = await utils.fetchWithLimit(post.cover, 1);
+        if (blob) {
+          await enqueue([blob], `${post.encodedName}/${post.cover.name}`);
         }
-        if (failedCount > 0) {
-          log(`完了 (${failedCount}件のダウンロードに失敗)`);
-        } else {
-          log("完了");
-        }
-        ctrl.close();
       }
-    });
-    if (window.WritableStream && readableZipStream.pipeTo) {
-      return readableZipStream.pipeTo(fileStream).then(() => console.log("done writing"));
+      let fileCount = 0;
+      for (const file of post.files) {
+        log(`download ${file.encodedName} (${++fileCount}/${post.files.length})`);
+        const blob = await utils.fetchWithLimit({ url: file.url, name: file.encodedName }, 1);
+        if (blob) {
+          await enqueue([blob], `${post.encodedName}/${file.encodedName}`);
+        } else {
+          failedCount++;
+          console.error(`${file.encodedName}(${file.url})のダウンロードに失敗、読み飛ばすよ`);
+          log(`${file.encodedName}のダウンロードに失敗`);
+        }
+        count++;
+        const remain = Math.floor(Math.abs(Math.floor(Date.now() / 1000) - startTime) * (downloadObj.fileCount - count) / count);
+        const h = remain / (60 * 60) | 0;
+        const m = Math.ceil((remain - 60 * 60 * h) / 60);
+        remainTime(`${h}:${("00" + m).slice(-2)}`);
+        progress(count * 100 / downloadObj.fileCount | 0);
+        await utils.sleep(100);
+      }
     }
-    const writer = fileStream.getWriter();
-    const reader = readableZipStream.getReader();
-    const pump = () => reader.read().then((res) => res.done ? writer.close() : writer.write(res.value).then(pump));
-    await pump();
+    if (failedCount > 0) {
+      log(`完了 (${failedCount}件のダウンロードに失敗)`);
+    } else {
+      log("完了");
+    }
+    await zip.close();
   }
   isDownloadJsonObj(target) {
     if (typeof target !== "object" || target === null) {

--- a/download-helper.test.ts
+++ b/download-helper.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
-import { DownloadHelper, type DownloadJsonObj, DownloadUtils, type FileObj, FileObject } from './download-helper';
+import {
+  crc32,
+  DownloadHelper,
+  type DownloadJsonObj,
+  DownloadUtils,
+  type FileObj,
+  FileObject,
+  ZipWriter,
+} from './download-helper';
 
 // ============================================================
 // 1. DownloadUtils tests
@@ -423,5 +431,172 @@ describe('isDownloadJsonObj', () => {
 
   test('空オブジェクト → false', () => {
     expect(helper.isDownloadJsonObj({})).toBe(false);
+  });
+});
+
+// ============================================================
+// 4. crc32 tests
+// ============================================================
+describe('crc32', () => {
+  const encoder = new TextEncoder();
+
+  test('空入力 → 0x00000000', () => {
+    expect(crc32(new Uint8Array(0))).toBe(0x00000000);
+  });
+
+  test('"123456789" → 0xCBF43926 (RFC 3720 テストベクタ)', () => {
+    expect(crc32(encoder.encode('123456789'))).toBe(0xcbf43926);
+  });
+
+  test('単一バイト入力', () => {
+    expect(crc32(new Uint8Array([0x00]))).toBe(0xd202ef8d);
+  });
+
+  test('日本語文字列の CRC-32', () => {
+    const data = encoder.encode('テスト');
+    const result = crc32(data);
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================
+// 5. ZipWriter tests
+// ============================================================
+describe('ZipWriter', () => {
+  const encoder = new TextEncoder();
+
+  /**
+   * FileSystemWritableFileStream のモック
+   */
+  class MockWritableStream {
+    chunks: Uint8Array[] = [];
+    closed = false;
+
+    async write(data: Uint8Array): Promise<void> {
+      this.chunks.push(new Uint8Array(data));
+    }
+
+    async close(): Promise<void> {
+      this.closed = true;
+    }
+
+    toBuffer(): Uint8Array {
+      const totalLength = this.chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+      const result = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const chunk of this.chunks) {
+        result.set(chunk, offset);
+        offset += chunk.length;
+      }
+      return result;
+    }
+  }
+
+  /**
+   * バッファから指定オフセットの 4 バイトを little-endian uint32 として読む
+   */
+  function readUint32(buf: Uint8Array, offset: number): number {
+    return new DataView(buf.buffer, buf.byteOffset).getUint32(offset, true);
+  }
+
+  /**
+   * バッファから指定オフセットの 2 バイトを little-endian uint16 として読む
+   */
+  function readUint16(buf: Uint8Array, offset: number): number {
+    return new DataView(buf.buffer, buf.byteOffset).getUint16(offset, true);
+  }
+
+  test('1 ファイルの ZIP を正しく生成', async () => {
+    const mock = new MockWritableStream();
+    const zip = new ZipWriter(mock as unknown as FileSystemWritableFileStream);
+
+    const data = encoder.encode('hello');
+    await zip.addFile('test.txt', data);
+    await zip.close();
+
+    const buf = mock.toBuffer();
+
+    // Local File Header signature
+    expect(readUint32(buf, 0)).toBe(0x04034b50);
+    // version needed
+    expect(readUint16(buf, 4)).toBe(20);
+    // general purpose bit flag (UTF-8)
+    expect(readUint16(buf, 6)).toBe(0x0800);
+    // compression method (stored)
+    expect(readUint16(buf, 8)).toBe(0);
+    // file name length
+    const nameLen = readUint16(buf, 26);
+    expect(nameLen).toBe(encoder.encode('test.txt').length);
+    // uncompressed size
+    expect(readUint32(buf, 22)).toBe(data.length);
+
+    // ファイルデータがヘッダ直後に存在
+    const fileDataOffset = 30 + nameLen;
+    const fileData = buf.slice(fileDataOffset, fileDataOffset + data.length);
+    expect(fileData).toEqual(data);
+
+    // Central Directory signature を探す
+    const cdOffset = fileDataOffset + data.length;
+    expect(readUint32(buf, cdOffset)).toBe(0x02014b50);
+
+    // EOCD signature を探す (末尾 22 バイト)
+    const eocdOffset = buf.length - 22;
+    expect(readUint32(buf, eocdOffset)).toBe(0x06054b50);
+    // EOCD エントリ数
+    expect(readUint16(buf, eocdOffset + 8)).toBe(1);
+    expect(readUint16(buf, eocdOffset + 10)).toBe(1);
+
+    expect(mock.closed).toBe(true);
+  });
+
+  test('複数ファイルの ZIP: エントリ数が正しい', async () => {
+    const mock = new MockWritableStream();
+    const zip = new ZipWriter(mock as unknown as FileSystemWritableFileStream);
+
+    await zip.addFile('a.txt', encoder.encode('aaa'));
+    await zip.addFile('b.txt', encoder.encode('bbb'));
+    await zip.addFile('c.txt', encoder.encode('ccc'));
+    await zip.close();
+
+    const buf = mock.toBuffer();
+    const eocdOffset = buf.length - 22;
+
+    expect(readUint32(buf, eocdOffset)).toBe(0x06054b50);
+    expect(readUint16(buf, eocdOffset + 8)).toBe(3);
+    expect(readUint16(buf, eocdOffset + 10)).toBe(3);
+  });
+
+  test('日本語ファイル名が UTF-8 で正しくエンコード', async () => {
+    const mock = new MockWritableStream();
+    const zip = new ZipWriter(mock as unknown as FileSystemWritableFileStream);
+
+    const fileName = 'テスト/画像.png';
+    const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header bytes
+    await zip.addFile(fileName, data);
+    await zip.close();
+
+    const buf = mock.toBuffer();
+    const nameLen = readUint16(buf, 26);
+    const expectedNameBytes = encoder.encode(fileName);
+    expect(nameLen).toBe(expectedNameBytes.length);
+
+    // ファイル名バイト列を比較
+    const nameBytes = buf.slice(30, 30 + nameLen);
+    expect(nameBytes).toEqual(expectedNameBytes);
+  });
+
+  test('CRC-32 が Local File Header に正しく記録', async () => {
+    const mock = new MockWritableStream();
+    const zip = new ZipWriter(mock as unknown as FileSystemWritableFileStream);
+
+    const data = encoder.encode('test data for crc');
+    const expectedCrc = crc32(data);
+    await zip.addFile('file.bin', data);
+    await zip.close();
+
+    const buf = mock.toBuffer();
+    // CRC-32 は Local File Header の offset 14
+    expect(readUint32(buf, 14)).toBe(expectedCrc);
   });
 });

--- a/download-helper.ts
+++ b/download-helper.ts
@@ -527,6 +527,145 @@ export class FileObject {
 }
 
 /**
+ * CRC-32 ルックアップテーブル (IEEE 802.3 polynomial)
+ * @internal
+ */
+export const crc32Table: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+
+/**
+ * CRC-32 を計算する
+ * @param data 対象データ
+ * @internal
+ */
+export function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc = crc32Table[(crc ^ data[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * BlobPart 配列を Uint8Array に変換する
+ */
+async function toUint8Array(parts: BlobPart[]): Promise<Uint8Array> {
+  const blob = new Blob(parts);
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/**
+ * ZIP ファイル書き込みクラス (stored / 非圧縮)
+ * File System Access API の FileSystemWritableFileStream に直接書き込む
+ * @internal
+ */
+export class ZipWriter {
+  private writable: FileSystemWritableFileStream;
+  private offset = 0;
+  private entries: { name: Uint8Array; crc: number; size: number; offset: number }[] = [];
+  private encoder = new TextEncoder();
+
+  constructor(writable: FileSystemWritableFileStream) {
+    this.writable = writable;
+  }
+
+  /**
+   * ファイルを ZIP に追加する
+   * @param name ZIP 内のファイルパス (UTF-8)
+   * @param data ファイルデータ
+   */
+  async addFile(name: string, data: Uint8Array): Promise<void> {
+    const nameBytes = this.encoder.encode(name);
+    const fileCrc = crc32(data);
+    const localHeaderOffset = this.offset;
+
+    // Local File Header (30 bytes + name length)
+    const header = new ArrayBuffer(30);
+    const view = new DataView(header);
+    view.setUint32(0, 0x04034b50, true); // signature
+    view.setUint16(4, 20, true); // version needed (2.0)
+    view.setUint16(6, 0x0800, true); // general purpose bit flag (bit 11 = UTF-8)
+    view.setUint16(8, 0, true); // compression method (stored)
+    view.setUint16(10, 0, true); // mod time
+    view.setUint16(12, 0, true); // mod date
+    view.setUint32(14, fileCrc, true); // crc-32
+    view.setUint32(18, data.length, true); // compressed size
+    view.setUint32(22, data.length, true); // uncompressed size
+    view.setUint16(26, nameBytes.length, true); // file name length
+    view.setUint16(28, 0, true); // extra field length
+
+    await this.write(new Uint8Array(header));
+    await this.write(nameBytes);
+    await this.write(data);
+
+    this.entries.push({ name: nameBytes, crc: fileCrc, size: data.length, offset: localHeaderOffset });
+  }
+
+  /**
+   * Central Directory と EOCD を書き込み、ストリームを閉じる
+   */
+  async close(): Promise<void> {
+    const cdOffset = this.offset;
+
+    for (const entry of this.entries) {
+      const cdHeader = new ArrayBuffer(46);
+      const view = new DataView(cdHeader);
+      view.setUint32(0, 0x02014b50, true); // signature
+      view.setUint16(4, 20, true); // version made by
+      view.setUint16(6, 20, true); // version needed
+      view.setUint16(8, 0x0800, true); // general purpose bit flag (UTF-8)
+      view.setUint16(10, 0, true); // compression method
+      view.setUint16(12, 0, true); // mod time
+      view.setUint16(14, 0, true); // mod date
+      view.setUint32(16, entry.crc, true); // crc-32
+      view.setUint32(20, entry.size, true); // compressed size
+      view.setUint32(24, entry.size, true); // uncompressed size
+      view.setUint16(28, entry.name.length, true); // file name length
+      view.setUint16(30, 0, true); // extra field length
+      view.setUint16(32, 0, true); // file comment length
+      view.setUint16(34, 0, true); // disk number start
+      view.setUint16(36, 0, true); // internal file attributes
+      view.setUint32(38, 0, true); // external file attributes
+      view.setUint32(42, entry.offset, true); // local header offset
+
+      await this.write(new Uint8Array(cdHeader));
+      await this.write(entry.name);
+    }
+
+    const cdSize = this.offset - cdOffset;
+
+    // End of Central Directory Record (22 bytes)
+    const eocd = new ArrayBuffer(22);
+    const eocdView = new DataView(eocd);
+    eocdView.setUint32(0, 0x06054b50, true); // signature
+    eocdView.setUint16(4, 0, true); // disk number
+    eocdView.setUint16(6, 0, true); // CD disk number
+    eocdView.setUint16(8, this.entries.length, true); // CD entries on this disk
+    eocdView.setUint16(10, this.entries.length, true); // total CD entries
+    eocdView.setUint32(12, cdSize, true); // CD size
+    eocdView.setUint32(16, cdOffset, true); // CD offset
+    eocdView.setUint16(20, 0, true); // comment length
+
+    await this.write(new Uint8Array(eocd));
+    await this.writable.close();
+  }
+
+  private async write(data: Uint8Array): Promise<void> {
+    await this.writable.write(data);
+    this.offset += data.length;
+  }
+}
+
+/**
  * ダウンロード用のヘルパー
  */
 export class DownloadHelper {
@@ -550,30 +689,6 @@ export class DownloadHelper {
   bootJS = {
     src: 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js',
     integrity: 'sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI',
-  };
-
-  /**
-   * web-streams-polyfill CDN情報
-   */
-  polyfillJS = {
-    src: 'https://cdn.jsdelivr.net/npm/web-streams-polyfill@2.0.2/dist/ponyfill.min.js',
-    integrity: 'sha384-ba6djMbY2Z/yqvSzlHRsh7WWPHEwE+TD2KdIhrpLv4q7+7izPZSlnWJe/t++aQOE',
-  };
-
-  /**
-   * StreamSaver CDN情報
-   */
-  streamSaverJS = {
-    src: 'https://cdn.jsdelivr.net/npm/streamsaver@2.0.6/StreamSaver.js',
-    integrity: 'sha384-Nqw6SzqA0IaGGLP/g9Y5h/bB8wBGXJ83TDjPs5OgxjX9mYZa5+oUc2Gym4xwZSSa',
-  };
-
-  /**
-   * zip-stream CDN情報
-   */
-  zipStreamJS = {
-    src: 'https://cdn.jsdelivr.net/npm/streamsaver@2.0.6/examples/zip-stream.js',
-    integrity: 'sha384-g9gkHBj/J34a/2KwwHmm6VymJgH8EivePV3Nhl9rGu/eKHhK0OthrHe5S7fW88Pn',
   };
 
   /**
@@ -706,86 +821,69 @@ export class DownloadHelper {
     remainTime: (r: string) => void,
   ) {
     if (!this.isDownloadJsonObj(downloadObj)) throw new Error('ダウンロード対象オブジェクトの型が不正');
-    const ui = this;
     const utils = this.utils;
-    await utils.embedScript(this.polyfillJS.src, this.polyfillJS.integrity);
-    await utils.embedScript(this.streamSaverJS.src, this.streamSaverJS.integrity);
-    await utils.embedScript(this.zipStreamJS.src, this.zipStreamJS.integrity);
     const encodedId = utils.encodeFileName(downloadObj.id);
-    const fileStream = streamSaver.createWriteStream(`${encodedId}.zip`);
 
-    const readableZipStream = new createWriter({
-      async pull(ctrl) {
-        const startTime = Math.floor(Date.now() / 1000);
-        let count = 0;
-        let failedCount = 0;
-        const enqueue = (fileBits: BlobPart[], path: string) =>
-          ctrl.enqueue(new File(fileBits, `${encodedId}/${path}`));
-        log(`@${downloadObj.id} 投稿:${downloadObj.postCount} ファイル:${downloadObj.fileCount}`);
-        // ルートhtml
-        enqueue([ui.createRootHtmlFromPosts(downloadObj)], 'index.html');
-        // 投稿処理
-        let postCount = 0;
-        for (const post of downloadObj.posts) {
-          log(`${post.originalName} (${++postCount}/${downloadObj.postCount})`);
-          // 投稿情報+html
-          const informationFile = utils.createInformationFile(post.informationText);
-          enqueue(informationFile.content, `${post.encodedName}/${utils.encodeFileName(informationFile.name)}`);
-          enqueue([ui.createHtmlFromBody(post.originalName, post.htmlText)], `${post.encodedName}/index.html`);
-          // カバー画像
-          if (post.cover) {
-            log(`download ${post.cover.name}`);
-            const blob = await utils.fetchWithLimit(post.cover, 1);
-            if (blob) {
-              enqueue([blob], `${post.encodedName}/${post.cover.name}`);
-            }
-          }
-          // ファイル処理
-          let fileCount = 0;
-          for (const file of post.files) {
-            log(`download ${file.encodedName} (${++fileCount}/${post.files.length})`);
-            const blob = await utils.fetchWithLimit({ url: file.url, name: file.encodedName }, 1);
-            if (blob) {
-              enqueue([blob], `${post.encodedName}/${file.encodedName}`);
-            } else {
-              failedCount++;
-              console.error(`${file.encodedName}(${file.url})のダウンロードに失敗、読み飛ばすよ`);
-              log(`${file.encodedName}のダウンロードに失敗`);
-            }
-            count++;
-            setTimeout(() => {
-              if (count <= 0) return;
-              const remain = Math.floor(
-                (Math.abs(Math.floor(Date.now() / 1000) - startTime) * (downloadObj.fileCount - count)) / count,
-              );
-              const h = (remain / (60 * 60)) | 0;
-              const m = Math.ceil((remain - 60 * 60 * h) / 60);
-              remainTime(`${h}:${('00' + m).slice(-2)}`);
-              progress(((count * 100) / downloadObj.fileCount) | 0);
-            }, 0);
-            await utils.sleep(100);
-          }
+    const handle = await showSaveFilePicker({ suggestedName: `${encodedId}.zip` });
+    const writable = await handle.createWritable();
+    const zip = new ZipWriter(writable);
+
+    const enqueue = async (fileBits: BlobPart[], path: string) => {
+      await zip.addFile(`${encodedId}/${path}`, await toUint8Array(fileBits));
+    };
+
+    const startTime = Math.floor(Date.now() / 1000);
+    let count = 0;
+    let failedCount = 0;
+
+    log(`@${downloadObj.id} 投稿:${downloadObj.postCount} ファイル:${downloadObj.fileCount}`);
+    // ルートhtml
+    await enqueue([this.createRootHtmlFromPosts(downloadObj)], 'index.html');
+    // 投稿処理
+    let postCount = 0;
+    for (const post of downloadObj.posts) {
+      log(`${post.originalName} (${++postCount}/${downloadObj.postCount})`);
+      // 投稿情報+html
+      const informationFile = utils.createInformationFile(post.informationText);
+      await enqueue(informationFile.content, `${post.encodedName}/${utils.encodeFileName(informationFile.name)}`);
+      await enqueue([this.createHtmlFromBody(post.originalName, post.htmlText)], `${post.encodedName}/index.html`);
+      // カバー画像
+      if (post.cover) {
+        log(`download ${post.cover.name}`);
+        const blob = await utils.fetchWithLimit(post.cover, 1);
+        if (blob) {
+          await enqueue([blob], `${post.encodedName}/${post.cover.name}`);
         }
-        if (failedCount > 0) {
-          log(`完了 (${failedCount}件のダウンロードに失敗)`);
+      }
+      // ファイル処理
+      let fileCount = 0;
+      for (const file of post.files) {
+        log(`download ${file.encodedName} (${++fileCount}/${post.files.length})`);
+        const blob = await utils.fetchWithLimit({ url: file.url, name: file.encodedName }, 1);
+        if (blob) {
+          await enqueue([blob], `${post.encodedName}/${file.encodedName}`);
         } else {
-          log('完了');
+          failedCount++;
+          console.error(`${file.encodedName}(${file.url})のダウンロードに失敗、読み飛ばすよ`);
+          log(`${file.encodedName}のダウンロードに失敗`);
         }
-        ctrl.close();
-      },
-    });
-
-    // more optimized
-    if (window.WritableStream && readableZipStream.pipeTo) {
-      return readableZipStream.pipeTo(fileStream).then(() => console.log('done writing'));
+        count++;
+        const remain = Math.floor(
+          (Math.abs(Math.floor(Date.now() / 1000) - startTime) * (downloadObj.fileCount - count)) / count,
+        );
+        const h = (remain / (60 * 60)) | 0;
+        const m = Math.ceil((remain - 60 * 60 * h) / 60);
+        remainTime(`${h}:${('00' + m).slice(-2)}`);
+        progress(((count * 100) / downloadObj.fileCount) | 0);
+        await utils.sleep(100);
+      }
     }
-
-    // less optimized
-    const writer = fileStream.getWriter();
-    const reader = readableZipStream.getReader();
-    const pump: () => Promise<void> = () =>
-      reader.read().then((res) => (res.done ? writer.close() : writer.write(res.value).then(pump)));
-    await pump();
+    if (failedCount > 0) {
+      log(`完了 (${failedCount}件のダウンロードに失敗)`);
+    } else {
+      log('完了');
+    }
+    await zip.close();
   }
 
   /**
@@ -1046,18 +1144,16 @@ export class DownloadHelper {
   }
 }
 
-declare const streamSaver: {
-  createWriteStream: (
-    fileName: string,
-    options?: {
-      size: null;
-      pathname: null;
-      writableStrategy: undefined;
-      readableStrategy: undefined;
-    },
-  ) => WritableStream;
-};
+declare function showSaveFilePicker(options?: {
+  suggestedName?: string;
+  types?: { description?: string; accept: Record<string, string[]> }[];
+}): Promise<FileSystemFileHandle>;
 
-declare const createWriter: new (underlyingSource: {
-  pull: (ctrl: { enqueue: (file: File) => void; close: () => void }) => Promise<void>;
-}) => ReadableStream & { pull: () => void };
+interface FileSystemFileHandle {
+  createWritable(): Promise<FileSystemWritableFileStream>;
+}
+
+interface FileSystemWritableFileStream extends WritableStream {
+  write(data: BufferSource | Blob | string): Promise<void>;
+  close(): Promise<void>;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-helper",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "ブックマークレットとかで使うUI",
   "scripts": {
     "build": "bun build ./download-helper.ts --outfile ./download-helper.js --format esm --target browser --no-bundle",


### PR DESCRIPTION
## Summary

- CDN 経由の外部ライブラリ 3 本 (web-streams-polyfill, StreamSaver.js, zip-stream.js) を除去
- `showSaveFilePicker` + 自前 `ZipWriter` による ZIP ストリーミング書き込みに置き換え
- CRC-32 テーブルルックアップと ZipWriter クラスを新規追加
- `downloadZip` を pull ベース (ReadableStream + pipeTo) から push ベースに書き換え
- CRC-32 / ZipWriter のユニットテストを追加
- バージョンを 3.5.0 に更新

## 制約

- Chrome / Edge 限定 (File System Access API を使用)
- ZIP64 非対応 (標準 ZIP 32-bit、4GB 超は未対応)

Closes #3

## Test plan

- [x] `bun run lint` — Biome エラーなし
- [x] `bun test` — 87 テスト全て pass
- [x] `bun run build` — download-helper.js が正常に生成
- [x] FANBOX 上でブックマークレットを実行し、ZIP ダウンロード (38MB) が正常に動作することを手動確認