### PR TITLE
createDownloadUI にオーバーレイモードを追加

### DIFF
--- a/download-helper.js
+++ b/download-helper.js
@@ -97,8 +97,8 @@ export class DownloadObject {
     this.downloadObj = { posts: {}, id };
     this.utils = utils;
   }
-  stringify() {
-    const downloadJson = {
+  toJsonObj() {
+    return {
       posts: this.orderedPosts.map((it) => it.toJsonObjBy(this.downloadObj.posts)),
       id: this.downloadObj.id,
       url: this.url,
@@ -106,7 +106,9 @@ export class DownloadObject {
       postCount: this.countPost(),
       fileCount: this.countFile()
     };
-    return JSON.stringify(downloadJson);
+  }
+  stringify() {
+    return JSON.stringify(this.toJsonObj());
   }
   setUrl(url) {
     this.url = url;
@@ -421,43 +423,56 @@ export class DownloadHelper {
     src: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js",
     integrity: "sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
   };
-  async createDownloadUI(title) {
-    document.head.innerHTML = "";
-    document.body.innerHTML = "";
-    document.getElementsByTagName("html")[0].style.height = "100%";
-    document.body.style.height = "100%";
-    document.body.style.margin = "0";
-    document.title = title;
-    const bootLink = document.createElement("link");
+  async createDownloadUI(title, options) {
+    const doc = options?.targetDocument ?? document;
+    const win = options?.targetWindow ?? window;
+    doc.head.innerHTML = "";
+    doc.body.innerHTML = "";
+    doc.getElementsByTagName("html")[0].style.height = "100%";
+    doc.body.style.height = "100%";
+    doc.body.style.margin = "0";
+    doc.title = title;
+    const bootLink = doc.createElement("link");
     bootLink.href = this.bootCSS.href;
     bootLink.rel = "stylesheet";
     bootLink.integrity = this.bootCSS.integrity;
     bootLink.crossOrigin = "anonymous";
-    document.head.appendChild(bootLink);
-    const bodyDiv = document.createElement("div");
+    doc.head.appendChild(bootLink);
+    const bodyDiv = doc.createElement("div");
     bodyDiv.style.display = "flex";
     bodyDiv.style.alignItems = "center";
     bodyDiv.style.justifyContent = "center";
     bodyDiv.style.flexDirection = "column";
     bodyDiv.style.height = "100%";
-    const inputDiv = document.createElement("div");
+    const inputDiv = doc.createElement("div");
     inputDiv.className = "input-group mb-2";
     inputDiv.style.width = "400px";
-    const input = document.createElement("input");
+    const input = doc.createElement("input");
     input.type = "text";
     input.className = "form-control";
     input.placeholder = "ここにJSONを貼り付け";
+    if (options?.prefillData) {
+      input.value = JSON.stringify(options.prefillData);
+    }
     inputDiv.appendChild(input);
-    const button = document.createElement("button");
+    const button = doc.createElement("button");
     button.className = "btn btn-outline-secondary btn-labeled";
     button.type = "button";
     button.innerText = "Download";
     inputDiv.appendChild(button);
+    if (options?.onClose) {
+      const closeButton = doc.createElement("button");
+      closeButton.className = "btn btn-outline-danger btn-labeled";
+      closeButton.type = "button";
+      closeButton.innerText = "Close";
+      closeButton.onclick = options.onClose;
+      inputDiv.appendChild(closeButton);
+    }
     bodyDiv.appendChild(inputDiv);
-    const progressDiv = document.createElement("div");
+    const progressDiv = doc.createElement("div");
     progressDiv.className = "progress mb-3";
     progressDiv.style.width = "400px";
-    const progress = document.createElement("div");
+    const progress = doc.createElement("div");
     progress.className = "progress-bar";
     progress.style.width = "0%";
     progress.innerText = "0%";
@@ -472,29 +487,29 @@ export class DownloadHelper {
     };
     progressDiv.appendChild(progress);
     bodyDiv.appendChild(progressDiv);
-    const infoDiv = document.createElement("div");
+    const infoDiv = doc.createElement("div");
     infoDiv.style.width = "350px";
-    const checkBoxDiv = document.createElement("div");
+    const checkBoxDiv = doc.createElement("div");
     checkBoxDiv.className = "form-check float-start";
-    const checkBox = document.createElement("input");
+    const checkBox = doc.createElement("input");
     checkBox.className = "form-check-input";
     checkBox.type = "checkbox";
     checkBox.id = "LogCheck";
     checkBox.checked = true;
     checkBoxDiv.appendChild(checkBox);
-    const checkBoxLabel = document.createElement("label");
+    const checkBoxLabel = doc.createElement("label");
     checkBoxLabel.className = "form-check-label";
     checkBoxLabel.setAttribute("for", "LogCheck");
     checkBoxLabel.innerText = "ログを自動スクロール";
     checkBoxDiv.appendChild(checkBoxLabel);
     infoDiv.appendChild(checkBoxDiv);
-    const remainTimeDiv = document.createElement("div");
+    const remainTimeDiv = doc.createElement("div");
     remainTimeDiv.className = "float-end";
     remainTimeDiv.innerText = "残りおよそ -:--";
     const setRemainTime = (r) => remainTimeDiv.innerText = `残りおよそ ${r}`;
     infoDiv.appendChild(remainTimeDiv);
     bodyDiv.appendChild(infoDiv);
-    const textarea = document.createElement("textarea");
+    const textarea = doc.createElement("textarea");
     textarea.className = "form-control";
     textarea.readOnly = true;
     textarea.style.resize = "both";
@@ -508,26 +523,60 @@ export class DownloadHelper {
       }
     };
     bodyDiv.appendChild(textarea);
-    document.body.appendChild(bodyDiv);
-    const bootScript = document.createElement("script");
+    doc.body.appendChild(bodyDiv);
+    const bootScript = doc.createElement("script");
     bootScript.src = this.bootJS.src;
     bootScript.integrity = this.bootJS.integrity;
     bootScript.crossOrigin = "anonymous";
-    document.body.appendChild(bootScript);
+    doc.body.appendChild(bootScript);
     const downloadFun = this.downloadZip.bind(this);
     button.onclick = async () => {
       button.disabled = true;
-      const loadingFun = (event) => event.returnValue = `downloading`;
-      window.addEventListener("beforeunload", loadingFun);
+      const loadingFun = (event) => event.returnValue = "downloading";
+      win.addEventListener("beforeunload", loadingFun);
       try {
         await downloadFun(JSON.parse(input.value), setProgress, textLog, setRemainTime);
       } catch (e) {
         textLog("エラー出た");
         console.error(e);
       } finally {
-        window.removeEventListener("beforeunload", loadingFun);
+        win.removeEventListener("beforeunload", loadingFun);
       }
     };
+  }
+  async createDownloadOverlay(title, parentDocument, data) {
+    const overlay = parentDocument.createElement("div");
+    overlay.style.position = "fixed";
+    overlay.style.top = "0";
+    overlay.style.left = "0";
+    overlay.style.width = "100%";
+    overlay.style.height = "100%";
+    overlay.style.backgroundColor = "rgba(0, 0, 0, 0.7)";
+    overlay.style.zIndex = "2147483647";
+    overlay.style.display = "flex";
+    overlay.style.alignItems = "center";
+    overlay.style.justifyContent = "center";
+    const iframe = parentDocument.createElement("iframe");
+    iframe.style.width = "100%";
+    iframe.style.height = "100%";
+    iframe.style.border = "none";
+    overlay.appendChild(iframe);
+    parentDocument.body.appendChild(overlay);
+    const closeOverlay = () => {
+      overlay.remove();
+    };
+    const iframeDoc = iframe.contentDocument;
+    const iframeWin = iframe.contentWindow;
+    if (!iframeDoc || !iframeWin) {
+      throw new Error("iframe の contentDocument/contentWindow を取得できません");
+    }
+    await this.createDownloadUI(title, {
+      targetDocument: iframeDoc,
+      targetWindow: iframeWin,
+      prefillData: data,
+      onClose: closeOverlay
+    });
+    return closeOverlay;
   }
   async downloadZip(downloadObj, progress, log, remainTime) {
     if (!this.isDownloadJsonObj(downloadObj))

--- a/download-helper.test.ts
+++ b/download-helper.test.ts
@@ -3,6 +3,7 @@ import {
   crc32,
   DownloadHelper,
   type DownloadJsonObj,
+  DownloadObject,
   DownloadUtils,
   type FileObj,
   FileObject,
@@ -598,5 +599,57 @@ describe('ZipWriter', () => {
     const buf = mock.toBuffer();
     // CRC-32 は Local File Header の offset 14
     expect(readUint32(buf, 14)).toBe(expectedCrc);
+  });
+});
+
+// ============================================================
+// 6. DownloadObject.toJsonObj tests
+// ============================================================
+describe('DownloadObject.toJsonObj', () => {
+  const utils = new DownloadUtils();
+
+  test('toJsonObj() と JSON.parse(stringify()) が同一の結果を返す', () => {
+    const obj = new DownloadObject('test-creator', utils);
+    obj.setUrl('https://example.com/@test-creator');
+    const post = obj.addPost('テスト投稿');
+    post.setInfo('{}');
+    post.setHtml('<p>content</p>');
+    post.setTags(['tag1', 'tag2']);
+    post.addFile('image', 'png', 'https://example.com/image.png');
+
+    const jsonObj = obj.toJsonObj();
+    const parsed = JSON.parse(obj.stringify());
+    expect(jsonObj).toEqual(parsed);
+  });
+
+  test('toJsonObj() のフィールドが正しい', () => {
+    const obj = new DownloadObject('creator-id', utils);
+    obj.setUrl('https://example.com');
+    obj.setTags(['tagA', 'tagB']);
+    const post = obj.addPost('投稿1');
+    post.setInfo('info-text');
+    post.setHtml('<p>html</p>');
+    post.setTags(['tagA']);
+    post.addFile('file1', 'jpg', 'https://example.com/file1.jpg');
+    post.addFile('file2', 'png', 'https://example.com/file2.png');
+
+    const result = obj.toJsonObj();
+    expect(result.id).toBe('creator-id');
+    expect(result.url).toBe('https://example.com');
+    expect(result.tags).toEqual(['tagA', 'tagB']);
+    expect(result.postCount).toBe(1);
+    expect(result.fileCount).toBe(2);
+    expect(result.posts).toHaveLength(1);
+    expect(result.posts[0].originalName).toBe('投稿1');
+    expect(result.posts[0].files).toHaveLength(2);
+  });
+
+  test('投稿が空の場合', () => {
+    const obj = new DownloadObject('empty', utils);
+    obj.setUrl('https://example.com');
+    const result = obj.toJsonObj();
+    expect(result.posts).toEqual([]);
+    expect(result.postCount).toBe(0);
+    expect(result.fileCount).toBe(0);
   });
 });

--- a/download-helper.ts
+++ b/download-helper.ts
@@ -41,6 +41,16 @@ export type DownloadJsonObj = {
 };
 
 /**
+ * ダウンロードUI生成オプション
+ */
+export type DownloadUIOptions = {
+  targetDocument?: Document;
+  targetWindow?: Window;
+  prefillData?: DownloadJsonObj;
+  onClose?: () => void;
+};
+
+/**
  * ダウンロード用のUtilityクラス
  */
 export class DownloadUtils {
@@ -253,8 +263,8 @@ export class DownloadObject {
     this.utils = utils;
   }
 
-  stringify(): string {
-    const downloadJson: DownloadJsonObj = {
+  toJsonObj(): DownloadJsonObj {
+    return {
       posts: this.orderedPosts.map((it) => it.toJsonObjBy(this.downloadObj.posts)),
       id: this.downloadObj.id,
       url: this.url,
@@ -262,7 +272,10 @@ export class DownloadObject {
       postCount: this.countPost(),
       fileCount: this.countFile(),
     };
-    return JSON.stringify(downloadJson);
+  }
+
+  stringify(): string {
+    return JSON.stringify(this.toJsonObj());
   }
 
   setUrl(url: string) {
@@ -694,46 +707,61 @@ export class DownloadHelper {
   /**
    * ダウンロード用のUIを作成する
    * @param title ダウンローダーの名前
+   * @param options UI生成オプション
    */
-  async createDownloadUI(title: string) {
-    document.head.innerHTML = '';
-    document.body.innerHTML = '';
-    document.getElementsByTagName('html')[0].style.height = '100%';
-    document.body.style.height = '100%';
-    document.body.style.margin = '0';
-    document.title = title;
+  async createDownloadUI(title: string, options?: DownloadUIOptions) {
+    const doc = options?.targetDocument ?? document;
+    const win = options?.targetWindow ?? window;
 
-    const bootLink = document.createElement('link');
+    doc.head.innerHTML = '';
+    doc.body.innerHTML = '';
+    doc.getElementsByTagName('html')[0].style.height = '100%';
+    doc.body.style.height = '100%';
+    doc.body.style.margin = '0';
+    doc.title = title;
+
+    const bootLink = doc.createElement('link');
     bootLink.href = this.bootCSS.href;
     bootLink.rel = 'stylesheet';
     bootLink.integrity = this.bootCSS.integrity;
     bootLink.crossOrigin = 'anonymous';
-    document.head.appendChild(bootLink);
+    doc.head.appendChild(bootLink);
 
-    const bodyDiv = document.createElement('div');
+    const bodyDiv = doc.createElement('div');
     bodyDiv.style.display = 'flex';
     bodyDiv.style.alignItems = 'center';
     bodyDiv.style.justifyContent = 'center';
     bodyDiv.style.flexDirection = 'column';
     bodyDiv.style.height = '100%';
-    const inputDiv = document.createElement('div');
+    const inputDiv = doc.createElement('div');
     inputDiv.className = 'input-group mb-2';
     inputDiv.style.width = '400px';
-    const input = document.createElement('input');
+    const input = doc.createElement('input');
     input.type = 'text';
     input.className = 'form-control';
     input.placeholder = 'ここにJSONを貼り付け';
+    if (options?.prefillData) {
+      input.value = JSON.stringify(options.prefillData);
+    }
     inputDiv.appendChild(input);
-    const button = document.createElement('button');
+    const button = doc.createElement('button');
     button.className = 'btn btn-outline-secondary btn-labeled';
     button.type = 'button';
     button.innerText = 'Download';
     inputDiv.appendChild(button);
+    if (options?.onClose) {
+      const closeButton = doc.createElement('button');
+      closeButton.className = 'btn btn-outline-danger btn-labeled';
+      closeButton.type = 'button';
+      closeButton.innerText = 'Close';
+      closeButton.onclick = options.onClose;
+      inputDiv.appendChild(closeButton);
+    }
     bodyDiv.appendChild(inputDiv);
-    const progressDiv = document.createElement('div');
+    const progressDiv = doc.createElement('div');
     progressDiv.className = 'progress mb-3';
     progressDiv.style.width = '400px';
-    const progress = document.createElement('div');
+    const progress = doc.createElement('div');
     progress.className = 'progress-bar';
     progress.style.width = '0%';
     progress.innerText = '0%';
@@ -748,29 +776,29 @@ export class DownloadHelper {
     };
     progressDiv.appendChild(progress);
     bodyDiv.appendChild(progressDiv);
-    const infoDiv = document.createElement('div');
+    const infoDiv = doc.createElement('div');
     infoDiv.style.width = '350px';
-    const checkBoxDiv = document.createElement('div');
+    const checkBoxDiv = doc.createElement('div');
     checkBoxDiv.className = 'form-check float-start';
-    const checkBox = document.createElement('input');
+    const checkBox = doc.createElement('input');
     checkBox.className = 'form-check-input';
     checkBox.type = 'checkbox';
     checkBox.id = 'LogCheck';
     checkBox.checked = true;
     checkBoxDiv.appendChild(checkBox);
-    const checkBoxLabel = document.createElement('label');
+    const checkBoxLabel = doc.createElement('label');
     checkBoxLabel.className = 'form-check-label';
     checkBoxLabel.setAttribute('for', 'LogCheck');
     checkBoxLabel.innerText = 'ログを自動スクロール';
     checkBoxDiv.appendChild(checkBoxLabel);
     infoDiv.appendChild(checkBoxDiv);
-    const remainTimeDiv = document.createElement('div');
+    const remainTimeDiv = doc.createElement('div');
     remainTimeDiv.className = 'float-end';
     remainTimeDiv.innerText = '残りおよそ -:--';
     const setRemainTime = (r: string) => (remainTimeDiv.innerText = `残りおよそ ${r}`);
     infoDiv.appendChild(remainTimeDiv);
     bodyDiv.appendChild(infoDiv);
-    const textarea = document.createElement('textarea');
+    const textarea = doc.createElement('textarea');
     textarea.className = 'form-control';
     textarea.readOnly = true;
     textarea.style.resize = 'both';
@@ -783,28 +811,75 @@ export class DownloadHelper {
       }
     };
     bodyDiv.appendChild(textarea);
-    document.body.appendChild(bodyDiv);
+    doc.body.appendChild(bodyDiv);
 
-    const bootScript = document.createElement('script');
+    const bootScript = doc.createElement('script');
     bootScript.src = this.bootJS.src;
     bootScript.integrity = this.bootJS.integrity;
     bootScript.crossOrigin = 'anonymous';
-    document.body.appendChild(bootScript);
+    doc.body.appendChild(bootScript);
     const downloadFun = this.downloadZip.bind(this);
 
     button.onclick = async () => {
       button.disabled = true;
-      const loadingFun = (event: BeforeUnloadEvent) => (event.returnValue = `downloading`);
-      window.addEventListener('beforeunload', loadingFun);
+      const loadingFun = (event: BeforeUnloadEvent) => (event.returnValue = 'downloading');
+      win.addEventListener('beforeunload', loadingFun);
       try {
         await downloadFun(JSON.parse(input.value), setProgress, textLog, setRemainTime);
       } catch (e) {
         textLog('エラー出た');
         console.error(e);
       } finally {
-        window.removeEventListener('beforeunload', loadingFun);
+        win.removeEventListener('beforeunload', loadingFun);
       }
     };
+  }
+
+  /**
+   * iframe オーバーレイでダウンロードUIを表示する
+   * @param title ダウンローダーの名前
+   * @param parentDocument オーバーレイを配置する親ドキュメント
+   * @param data 事前投入するデータ
+   * @returns オーバーレイを閉じる関数
+   */
+  async createDownloadOverlay(title: string, parentDocument: Document, data?: DownloadJsonObj): Promise<() => void> {
+    const overlay = parentDocument.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.7)';
+    overlay.style.zIndex = '2147483647';
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+
+    const iframe = parentDocument.createElement('iframe');
+    iframe.style.width = '100%';
+    iframe.style.height = '100%';
+    iframe.style.border = 'none';
+    overlay.appendChild(iframe);
+    parentDocument.body.appendChild(overlay);
+
+    const closeOverlay = () => {
+      overlay.remove();
+    };
+
+    const iframeDoc = iframe.contentDocument;
+    const iframeWin = iframe.contentWindow;
+    if (!iframeDoc || !iframeWin) {
+      throw new Error('iframe の contentDocument/contentWindow を取得できません');
+    }
+
+    await this.createDownloadUI(title, {
+      targetDocument: iframeDoc,
+      targetWindow: iframeWin,
+      prefillData: data,
+      onClose: closeOverlay,
+    });
+
+    return closeOverlay;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-helper",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "ブックマークレットとかで使うUI",
   "scripts": {
     "build": "bun build ./download-helper.ts --outfile ./download-helper.js --format esm --target browser --no-bundle",


### PR DESCRIPTION
## Summary
- `DownloadUIOptions` 型を追加し、`createDownloadUI` が任意の `Document`/`Window` に対して UI を生成できるようにリファクタ
- `createDownloadOverlay` メソッドを追加: 親ページ上に iframe オーバーレイでダウンロード UI を表示
- `DownloadObject.toJsonObj()` を追加: `stringify()` の内部ロジックを分離し、JSON 文字列化なしにデータを取得可能に
- version 3.5.0 → 3.6.0

Closes #5

## Test plan
- [x] `bun test` で既存テスト 87 件が全て通ること
- [x] `bun run lint` でエラーなし
- [x] `bun run build` が成功すること